### PR TITLE
Update README.md, now with a working link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@ Import of PlaneShift's SVN repository, 2018-07-31
 Imported by kyanha@github, with all SVN committers' email addresses
 set to their username@users.sourceforge.net email reflectors.
 
-[The original website](https://www.planeshift.it/Source%20code) also
-has links to instructions for compiling it.
+You can also find [instructions for compiling](https://kyanha.github.io/planeshift/compiling.html).
+
+Here's [the original website](https://www.planeshift.it/Source%20code).


### PR DESCRIPTION
The link at the original website to compiling instructions was dead.  Since the instructions are in the repository anyway, I created a github.io site and created a link to the compiling instructions there.